### PR TITLE
Move model structs of rollup-state-manager and prover-cluster to this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 babyjubjub-rs = { git = "https://github.com/Fluidex/babyjubjub-rs" }
 cfg-if = "1.0"
+chrono = { version = "0.4.19", features = [ "serde" ], optional = true }
 ff = { git = "https://github.com/Fluidex/ff", package = "ff_ce" }
 fnv = "1.0"
 futures = "0.3"
@@ -35,7 +36,7 @@ kafka = [ "rdkafka" ]
 num-bigint-default = [ "num-bigint/rand" ]
 rdkafka-dynamic = [ "rdkafka/dynamic_linking" ]
 rollup-state-db = [ "db" ]
-db = [ "sqlx" ]
+db = [ "chrono", "serde_json", "sqlx" ]
 rust-decimal-default = [ "rust_decimal/maths", "rust_decimal/serde_json", "serde_json" ]
 rust-decimal-dingir-exchange = [ "rust_decimal/postgres", "rust_decimal/bytes", "rust_decimal/byteorder" ]
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,9 +1,10 @@
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "db"))] {
-        pub type DbType = sqlx::Postgres;
+    if #[cfg(feature = "db")] {
         pub type ConnectionType = sqlx::postgres::PgConnection;
-        pub type PoolOptions = sqlx::postgres::PgPoolOptions;
         pub type DBErrType = sqlx::Error;
+        pub type DbType = sqlx::Postgres;
+        pub type PoolOptions = sqlx::postgres::PgPoolOptions;
+        pub type TimestampDbType = chrono::NaiveDateTime;
     }
 }
 
@@ -13,3 +14,5 @@ cfg_if::cfg_if! {
         pub use migrator::MIGRATOR;
     }
 }
+
+pub mod models;

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -2,6 +2,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "rollup-state-db")] {
         mod rollup_state;
         pub use rollup_state::tablenames;
+        pub use rollup_state::l2_block;
         pub use rollup_state::task;
     }
 }

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -1,0 +1,7 @@
+cfg_if::cfg_if! {
+    if #[cfg(feature = "rollup-state-db")] {
+        mod rollup_state;
+        pub use rollup_state::tablenames;
+        pub use rollup_state::task;
+    }
+}

--- a/src/db/models/rollup_state/l2_block.rs
+++ b/src/db/models/rollup_state/l2_block.rs
@@ -1,0 +1,10 @@
+use crate::db::TimestampDbType;
+use serde::Serialize;
+
+#[derive(sqlx::FromRow, Serialize, Debug, Clone)]
+pub struct L2Block {
+    pub block_id: i64,
+    pub new_root: String,
+    pub witness: serde_json::Value,
+    pub created_time: TimestampDbType,
+}

--- a/src/db/models/rollup_state/mod.rs
+++ b/src/db/models/rollup_state/mod.rs
@@ -3,4 +3,5 @@ pub mod tablenames {
     pub const TASK: &str = "task";
 }
 
+pub mod l2_block;
 pub mod task;

--- a/src/db/models/rollup_state/mod.rs
+++ b/src/db/models/rollup_state/mod.rs
@@ -1,0 +1,6 @@
+pub mod tablenames {
+    pub const L2_BLOCK: &str = "l2block";
+    pub const TASK: &str = "task";
+}
+
+pub mod task;

--- a/src/db/models/rollup_state/task.rs
+++ b/src/db/models/rollup_state/task.rs
@@ -1,0 +1,34 @@
+use crate::db::TimestampDbType;
+use serde::{Deserialize, Serialize};
+
+#[derive(sqlx::Type, Serialize, Debug, Clone)]
+#[sqlx(type_name = "task_status", rename_all = "snake_case")]
+pub enum TaskStatus {
+    Inited,
+    Witgening,
+    Ready,
+    Assigned,
+    Proved,
+}
+
+#[derive(sqlx::Type, Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[sqlx(type_name = "varchar", rename_all = "lowercase")]
+pub enum CircuitType {
+    BLOCK,
+}
+
+#[derive(sqlx::FromRow, Serialize, Debug, Clone)]
+pub struct Task {
+    pub task_id: String,
+    pub circuit: CircuitType,
+    pub block_id: i64,
+    pub input: serde_json::Value,
+    pub output: Option<serde_json::Value>,
+    pub witness: Option<Vec<u8>>,
+    pub public_input: Option<Vec<u8>>,
+    pub proof: Option<Vec<u8>>,
+    pub status: TaskStatus,
+    pub prover_id: Option<String>,
+    pub created_time: TimestampDbType,
+    pub updated_time: TimestampDbType,
+}


### PR DESCRIPTION
Part 2 of issue https://github.com/Fluidex/rollup-state-manager/issues/131

Copies model files from `rollup-state-manager` and `prover-cluster`.