### PR TITLE
Add `timeutil` as a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 babyjubjub-rs = { git = "https://github.com/Fluidex/babyjubjub-rs" }
 backtrace = { version = "0.3", optional = true }
 cfg-if = "1.0"
-chrono = { version = "0.4.19", features = [ "serde" ], optional = true }
+chrono = { version = "0.4.19", features = [ "serde" ] }
 ff = { git = "https://github.com/Fluidex/ff", package = "ff_ce" }
 fnv = "1.0"
 futures = "0.3"
@@ -41,7 +41,7 @@ kafka = [ "rdkafka" ]
 num-bigint-default = [ "num-bigint/rand" ]
 rdkafka-dynamic = [ "rdkafka/dynamic_linking" ]
 rollup-state-db = [ "db" ]
-db = [ "chrono", "serde_json", "sqlx" ]
+db = [ "serde_json", "sqlx" ]
 rust-decimal-default = [ "rust_decimal/maths", "rust_decimal/serde_json", "serde_json" ]
 rust-decimal-dingir-exchange = [ "rust_decimal/postgres", "rust_decimal/bytes", "rust_decimal/byteorder" ]
 non-blocking-tracing = [ "backtrace", "tracing", "tracing-appender", "tracing-subscriber" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod message;
 pub mod non_blocking_tracing;
 pub mod serde;
 pub mod types;
+pub mod utils;
 
 pub use types::Fr;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod timeutil;

--- a/src/utils/timeutil.rs
+++ b/src/utils/timeutil.rs
@@ -1,0 +1,61 @@
+use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub fn system_time_to_timestamp(t: SystemTime) -> f64 {
+    t.duration_since(UNIX_EPOCH).unwrap().as_micros() as f64 / 1_000_000_f64
+}
+
+pub fn timestamp_to_system_time(t: f64) -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs_f64(t)
+}
+
+pub fn current_system_time() -> SystemTime {
+    SystemTime::now()
+}
+
+pub fn current_timestamp() -> f64 {
+    system_time_to_timestamp(current_system_time())
+}
+
+pub fn current_naive_time() -> NaiveDateTime {
+    chrono::Local::now().naive_local()
+}
+
+pub struct FTimestamp(pub f64);
+
+impl From<FTimestamp> for f64 {
+    fn from(f: FTimestamp) -> f64 {
+        f.0
+    }
+}
+
+impl From<&f64> for FTimestamp {
+    fn from(f: &f64) -> FTimestamp {
+        FTimestamp(*f)
+    }
+}
+
+impl From<FTimestamp> for NaiveDateTime {
+    fn from(f: FTimestamp) -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(f.0 as i64, ((f.0 - f.0 as i64 as f64) * 1e9) as u32)
+    }
+}
+
+impl From<&NaiveDateTime> for FTimestamp {
+    fn from(f: &NaiveDateTime) -> FTimestamp {
+        FTimestamp(f.timestamp_nanos() as f64 / 1e9)
+    }
+}
+
+impl From<&DateTime<Utc>> for FTimestamp {
+    fn from(f: &DateTime<Utc>) -> FTimestamp {
+        FTimestamp(f.timestamp() as f64)
+    }
+}
+
+impl From<FTimestamp> for DateTime<Utc> {
+    fn from(f: FTimestamp) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(f.into(), Utc)
+    }
+}


### PR DESCRIPTION
Moves https://github.com/Fluidex/dingir-exchange/blob/master/src/utils/timeutil.rs to this crate as a default feature.

Will use `timeutil` when implementing https://github.com/Fluidex/rollup-state-manager/issues/105.