### PR TITLE
Fix the type of model `l2_block` field `block_id` from i64 to i32

### DIFF
--- a/src/db/models/rollup_state/l2_block.rs
+++ b/src/db/models/rollup_state/l2_block.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 #[derive(sqlx::FromRow, Serialize, Debug, Clone)]
 pub struct L2Block {
-    pub block_id: i64,
+    pub block_id: i32,
     pub new_root: String,
     pub witness: serde_json::Value,
     pub created_time: TimestampDbType,


### PR DESCRIPTION
Found this issue when testing PR https://github.com/Fluidex/rollup-state-manager/pull/146