### PR TITLE
Remove column `witness` from table task and task status `Witgening` and `Witgened`

### DIFF
--- a/migrations/rollup_state/20210330142700_task.sql
+++ b/migrations/rollup_state/20210330142700_task.sql
@@ -1,4 +1,4 @@
-CREATE TYPE task_status AS ENUM('inited', 'witgening', 'witgened', 'proving', 'proved');
+CREATE TYPE task_status AS ENUM('inited', 'proving', 'proved');
 
 CREATE TABLE task (
     task_id VARCHAR(30) NOT NULL,
@@ -6,7 +6,6 @@ CREATE TABLE task (
     block_id BIGINT NOT NULL, -- TODO: combine with task_id
     input jsonb NOT NULL,
     output jsonb DEFAULT NULL,
-    witness BYTEA DEFAULT NULL,
     public_input BYTEA DEFAULT NULL,
     proof BYTEA DEFAULT NULL,
     status task_status NOT NULL DEFAULT 'inited',

--- a/src/db/models/rollup_state/task.rs
+++ b/src/db/models/rollup_state/task.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 #[sqlx(type_name = "task_status", rename_all = "snake_case")]
 pub enum TaskStatus {
     Inited,
-    Witgening,
-    Witgened,
     Proving,
     Proved,
 }
@@ -24,7 +22,6 @@ pub struct Task {
     pub block_id: i64,
     pub input: serde_json::Value,
     pub output: Option<serde_json::Value>,
-    pub witness: Option<Vec<u8>>,
     pub public_input: Option<Vec<u8>>,
     pub proof: Option<Vec<u8>>,
     pub status: TaskStatus,


### PR DESCRIPTION
Part of issue https://github.com/fluidex/prover-cluster/issues/105