### PR TITLE
Update task table for submitting block with data availability

### DIFF
--- a/migrations/rollup_state/20210626034404_l2block.sql
+++ b/migrations/rollup_state/20210626034404_l2block.sql
@@ -3,6 +3,7 @@ CREATE TYPE block_status AS ENUM('uncommited', 'commited', 'verified');
 CREATE TABLE l2block (
     block_id BIGINT PRIMARY KEY,
     new_root VARCHAR(256) NOT NULL,
+    raw_public_data bytea DEFAULT NULL,
     status block_status NOT NULL DEFAULT 'uncommited',
     l1_tx_hash VARCHAR(66) DEFAULT NULL,
     detail jsonb NOT NULL,

--- a/migrations/rollup_state/20211110082816_task_update.sql
+++ b/migrations/rollup_state/20211110082816_task_update.sql
@@ -1,4 +1,0 @@
--- Add migration script here
-
--- public data is used for submit block in L1 contract
-ALTER TABLE task ADD public_data bytea;

--- a/migrations/rollup_state/20211110082816_task_update.sql
+++ b/migrations/rollup_state/20211110082816_task_update.sql
@@ -1,0 +1,4 @@
+-- Add migration script here
+
+-- public data is used for submit block in L1 contract
+ALTER TABLE task ADD public_data bytea;

--- a/src/db/models/rollup_state/l2_block.rs
+++ b/src/db/models/rollup_state/l2_block.rs
@@ -13,6 +13,7 @@ pub enum BlockStatus {
 pub struct L2Block {
     pub block_id: i64, // TODO: keep this consistent with the smart contract
     pub new_root: String,
+    pub raw_public_data: Option<Vec<u8>>,
     pub status: BlockStatus,
     pub l1_tx_hash: Option<String>,
     pub detail: serde_json::Value,


### PR DESCRIPTION
With data availability, to submit a block require two fields: new root and public data, the former can be derived from public_input col while the later is just the preimage of two public_input fields (txDataHashLo/Hi) and has not been included in task table yet.

I also include some updating for on float.rs