### PR TITLE
Call `rescale` for float precision format

### DIFF
--- a/src/types/floats.rs
+++ b/src/types/floats.rs
@@ -134,7 +134,7 @@ impl<T: PrimInt + Zero, const NBITS: usize> Floats<T, NBITS> {
         if (self.exponent as u32) < prec {
             ret.set_scale(prec - self.exponent as u32).unwrap();
         } else {
-            ret = ret * Decimal::new(10, 0).pow(self.exponent as u64 - prec as u64);
+            ret *= Decimal::new(10, 0).pow(self.exponent as u64 - prec as u64);
         }
 
         ret.rescale(prec);

--- a/src/types/floats.rs
+++ b/src/types/floats.rs
@@ -133,10 +133,12 @@ impl<T: PrimInt + Zero, const NBITS: usize> Floats<T, NBITS> {
         let mut ret = Decimal::from_i128(self.significand.to_i128().unwrap()).unwrap();
         if (self.exponent as u32) < prec {
             ret.set_scale(prec - self.exponent as u32).unwrap();
-            ret
         } else {
-            ret * Decimal::new(10, 0).pow(self.exponent as u64 - prec as u64)
+            ret = ret * Decimal::new(10, 0).pow(self.exponent as u64 - prec as u64);
         }
+
+        ret.rescale(prec);
+        ret
     }
 
     pub fn from_bigint(bi: BigInt) -> Result<Self> {


### PR DESCRIPTION
Try to fix https://github.com/fluidex/rollup-state-manager/issues/228

`rescale` doesn't change the number - https://docs.rs/rust_decimal/1.17.0/rust_decimal/prelude/struct.Decimal.html#method.rescale

Test with PR https://github.com/fluidex/rollup-state-manager/pull/237